### PR TITLE
feat(va): add Value Averaging strategy (UI+logic+KPI+logs+charts) alongside DCA

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,16 @@
       <h2 class="text-lg md:text-xl font-bold mb-3">Strategy A</h2>
 
       <section class="panel p-4 md:p-5 mb-5">
-        <div class="grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
+        <div class="grid grid-cols-1 md:grid-cols-7 gap-3 items-end">
+          <div>
+            <div class="label">Strategy</div>
+            <div class="field">
+              <select id="a_type">
+                <option value="dca" selected>DCA</option>
+                <option value="va">VA</option>
+              </select>
+            </div>
+          </div>
           <div>
             <div class="label">Repeat</div>
             <div class="field">
@@ -168,9 +177,29 @@
               </select>
             </div>
           </div>
-          <div>
+          <div class="cfg-dca">
             <div class="label">Amount per buy (USD)</div>
             <div class="field"><input id="a_amount" type="number" min="1" step="1" value="100" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Target step (USD/kỳ)</div>
+            <div class="field"><input id="a_targetStep" type="number" min="1" step="1" value="100" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Initial target (USD)</div>
+            <div class="field"><input id="a_initialTarget" type="number" min="0" step="1" value="100" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Max contribution (USD, optional)</div>
+            <div class="field"><input id="a_maxContrib" type="number" min="0" step="1" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Carry shortfall</div>
+            <div class="field flex items-center justify-center"><input id="a_carryShort" type="checkbox" checked /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Allow sells</div>
+            <div class="field flex items-center justify-center"><input id="a_allowSells" type="checkbox" /></div>
           </div>
           <div>
             <div class="label">Start date</div>
@@ -194,8 +223,15 @@
         <div class="panel p-3.5"><div class="label">BTC accumulated</div><div id="a_k_btc" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Average cost</div><div id="a_k_avg" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Final value</div><div id="a_k_value" class="value mt-1">-</div></div>
-        <div class="panel p-3.5"><div class="label">DCA return</div><div id="a_k_pnl" class="value mt-1">-</div></div>
+        <div class="panel p-3.5"><div class="label">DCA/VA return</div><div id="a_k_pnl" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">vs. Lump-sum</div><div id="a_k_vsls" class="value mt-1">-</div></div>
+      </section>
+
+      <section id="a_vaRow" class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5 kpi" style="display:none">
+        <div class="panel p-3.5"><div class="label">Target step</div><div id="a_k_targetStep" class="value mt-1">-</div></div>
+        <div class="panel p-3.5"><div class="label">Skipped periods</div><div id="a_k_skipped" class="value mt-1">-</div></div>
+        <div class="panel p-3.5"><div class="label">Shortfall</div><div id="a_k_shortfall" class="value mt-1">-</div></div>
+        <div class="panel p-3.5" id="a_k_grossWrap"><div class="label">Gross buys / sells</div><div id="a_k_gross" class="value mt-1">-</div></div>
       </section>
 
       <section class="panel p-4 md:p-5">
@@ -252,7 +288,7 @@
         <summary class="cursor-pointer font-semibold text-base">Transaction details (A)</summary>
         <div class="mt-3">
           <table class="tbl-compact">
-            <thead><tr><th>#</th><th>Date</th><th>Price</th><th>Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th></tr></thead>
+            <thead id="a_logHead"><tr><th>#</th><th>Date</th><th>Price</th><th>Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th></tr></thead>
             <tbody id="a_log"></tbody>
           </table>
         </div>
@@ -264,7 +300,16 @@
       <h2 class="text-lg md:text-xl font-bold mb-3">Strategy B</h2>
 
       <section class="panel p-4 md:p-5 mb-5">
-        <div class="grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
+        <div class="grid grid-cols-1 md:grid-cols-7 gap-3 items-end">
+          <div>
+            <div class="label">Strategy</div>
+            <div class="field">
+              <select id="b_type">
+                <option value="dca" selected>DCA</option>
+                <option value="va">VA</option>
+              </select>
+            </div>
+          </div>
           <div>
             <div class="label">Repeat</div>
             <div class="field">
@@ -275,9 +320,29 @@
               </select>
             </div>
           </div>
-          <div>
+          <div class="cfg-dca">
             <div class="label">Amount per buy (USD)</div>
             <div class="field"><input id="b_amount" type="number" min="1" step="1" value="100" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Target step (USD/kỳ)</div>
+            <div class="field"><input id="b_targetStep" type="number" min="1" step="1" value="100" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Initial target (USD)</div>
+            <div class="field"><input id="b_initialTarget" type="number" min="0" step="1" value="100" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Max contribution (USD, optional)</div>
+            <div class="field"><input id="b_maxContrib" type="number" min="0" step="1" /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Carry shortfall</div>
+            <div class="field flex items-center justify-center"><input id="b_carryShort" type="checkbox" checked /></div>
+          </div>
+          <div class="cfg-va hidden">
+            <div class="label">Allow sells</div>
+            <div class="field flex items-center justify-center"><input id="b_allowSells" type="checkbox" /></div>
           </div>
           <div>
             <div class="label">Start date</div>
@@ -301,8 +366,15 @@
         <div class="panel p-3.5"><div class="label">BTC accumulated</div><div id="b_k_btc" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Average cost</div><div id="b_k_avg" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Final value</div><div id="b_k_value" class="value mt-1">-</div></div>
-        <div class="panel p-3.5"><div class="label">DCA return</div><div id="b_k_pnl" class="value mt-1">-</div></div>
+        <div class="panel p-3.5"><div class="label">DCA/VA return</div><div id="b_k_pnl" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">vs. Lump-sum</div><div id="b_k_vsls" class="value mt-1">-</div></div>
+      </section>
+
+      <section id="b_vaRow" class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5 kpi" style="display:none">
+        <div class="panel p-3.5"><div class="label">Target step</div><div id="b_k_targetStep" class="value mt-1">-</div></div>
+        <div class="panel p-3.5"><div class="label">Skipped periods</div><div id="b_k_skipped" class="value mt-1">-</div></div>
+        <div class="panel p-3.5"><div class="label">Shortfall</div><div id="b_k_shortfall" class="value mt-1">-</div></div>
+        <div class="panel p-3.5" id="b_k_grossWrap"><div class="label">Gross buys / sells</div><div id="b_k_gross" class="value mt-1">-</div></div>
       </section>
 
       <section class="panel p-4 md:p-5">
@@ -359,7 +431,7 @@
         <summary class="cursor-pointer font-semibold text-base">Transaction details (B)</summary>
         <div class="mt-3">
           <table class="tbl-compact">
-            <thead><tr><th>#</th><th>Date</th><th>Price</th><th>Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th></tr></thead>
+            <thead id="b_logHead"><tr><th>#</th><th>Date</th><th>Price</th><th>Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th></tr></thead>
             <tbody id="b_log"></tbody>
           </table>
         </div>
@@ -475,6 +547,54 @@ function runDCA(series,freq,amount,sISO,eISO){
   return { scheduleCount:schedule.length, invested, btc, avgCost:btc?invested/btc:0, lastPrice:last, value:btc*last,
            firstBuyDate:schedule[0]||null, logRows:log, portfolioSeries:port, investedSeries:invS };
 }
+
+function runVA(series,freq,vaParams,sISO,eISO){
+  const {targetStep, initialTarget, maxContribution, carryShort, allowSells} = vaParams;
+  const schedule=buildSchedule(freq,sISO,eISO);
+  const set=new Set(schedule);
+  let btc=0, invested=0, carry=0, skipped=0, grossBuy=0, grossSell=0;
+  let firstBuyDate=null;
+  const log=[], port=[], invS=[];
+  let t=0;
+  for(const p of series){
+    if(set.has(p.date)){
+      t++;
+      const target=initialTarget + t*targetStep;
+      const valuePrev=btc*p.close;
+      let delta=target - valuePrev;
+      let buy=0, sell=0, action='Skip';
+      if(allowSells){
+        let desired=delta;
+        if(desired>0){
+          buy = maxContribution!=null?Math.min(desired,maxContribution):desired;
+          if(buy>0){ btc+=buy/p.close; invested+=buy; grossBuy+=buy; action='Buy'; if(!firstBuyDate) firstBuyDate=p.date; }
+        } else if(desired<0){
+          sell = Math.min(-desired, valuePrev);
+          if(sell>0){ btc-=sell/p.close; invested-=sell; grossSell+=sell; action='Sell'; }
+        }
+        carry=0;
+      } else {
+        let desired=delta + (carryShort?carry:0);
+        buy=Math.max(desired,0);
+        if(maxContribution!=null) buy=Math.min(buy,maxContribution);
+        if(buy>0){ btc+=buy/p.close; invested+=buy; grossBuy+=buy; action='Buy'; if(!firstBuyDate) firstBuyDate=p.date; }
+        else { if(delta<=0) skipped++; }
+        carry = carryShort?Math.max(0,desired-buy):0;
+      }
+      const value=btc*p.close;
+      const deltaUSD=buy-sell;
+      const pnlAbs=value-invested;
+      const pnlPct=invested>0?(value/invested-1)*100:null;
+      log.push({date:p.date, price:p.close, target, action, deltaUSD, invested_cum:invested, value, pnl_abs:pnlAbs, pnl_pct:pnlPct});
+    }
+    invS.push({date:p.date, invested});
+    port.push({date:p.date, price:p.close, value:btc*p.close, invested});
+  }
+  const last=series[series.length-1].close;
+  return { scheduleCount:schedule.length, invested, btc, avgCost:btc?invested/btc:0, lastPrice:last, value:btc*last,
+           firstBuyDate:firstBuyDate, logRows:log, portfolioSeries:port, investedSeries:invS,
+           skipped, shortfallFinal:carry, grossBuy, grossSell };
+}
 function calcLumpSum(invested,firstBuyDate,lastPrice){
   const entry=PRICE_MAP.get(firstBuyDate); if(!entry) return null; const qty=invested/entry; return {entryPrice:entry, btc:qty, value:qty*lastPrice};
 }
@@ -498,6 +618,12 @@ function createWorkspace(prefix){
     get amount(){ return Math.max(1, Number(el('amount').value||0)); },
     get sISO(){ return el('startDate').value; },
     get eISO(){ return el('endDate').value; },
+    getType(){ return el('type').value; },
+    getTargetStep(){ return Math.max(1, Number(el('targetStep').value||100)); },
+    getInitialTarget(){ return Math.max(0, Number(el('initialTarget').value||this.getTargetStep())); },
+    getMaxContrib(){ const v=Number(el('maxContrib').value); return isFinite(v)&&v>0?v:null; },
+    getCarryShort(){ return el('carryShort').checked; },
+    getAllowSells(){ return el('allowSells').checked; },
     get maOn(){ return el('maOn').checked; }, get emaOn(){ return el('emaOn').checked; },
     get rsiOn(){ return el('rsiOn').checked; }, get rsiAlertOn(){ return el('rsiAlertOn').checked; },
     get maP(){ return clamp(Number(el('maPeriod').value||50),2,5000); },
@@ -522,6 +648,13 @@ function createWorkspace(prefix){
       return { ma:this.maOn?SMA(priceArray,this.maP):null,
                ema:this.emaOn?EMA(priceArray,this.emaP):null,
                rsi:this.rsiOn?RSI(priceArray,this.rsiP):null };
+    },
+
+    toggleStrategy(){
+      const type=this.getType();
+      const scope=document.getElementById(prefix.toUpperCase());
+      scope.querySelectorAll('.cfg-dca').forEach(d=>d.classList.toggle('hidden',type!=='dca'));
+      scope.querySelectorAll('.cfg-va').forEach(d=>d.classList.toggle('hidden',type!=='va'));
     },
 
     renderCharts(series, investedSeries, indicators){
@@ -600,27 +733,56 @@ function createWorkspace(prefix){
       });
     }, // end renderCharts
 
-    updateKPI(r,ls){
-      const invested=r.invested, value=r.value, pnlPct=invested>0?(value/invested-1)*100:0;
-      el('k_trades').textContent=fmt(r.scheduleCount,0);
-      el('k_invested').textContent=compactUSD(invested);
+    updateKPI(r,ls,mode){
+      const invested=r.invested, value=r.value;
+      const pnlPct=invested>0?(value/invested-1)*100:null;
+      const buyCount=mode==='va'?r.logRows.filter(x=>x.action==='Buy').length:r.scheduleCount;
+      const sellCount=mode==='va'?r.logRows.filter(x=>x.action==='Sell').length:0;
+      el('k_trades').textContent = sellCount>0?`${fmt(buyCount,0)} (Sells: ${fmt(sellCount,0)})`:fmt(buyCount,0);
+      const kinv=el('k_invested'); kinv.textContent=compactUSD(invested); kinv.title='Net cashflow';
       el('k_btc').textContent=fmt(r.btc,3);
-      el('k_avg').textContent=r.avgCost?compactUSD(r.avgCost):'-';
+      el('k_avg').textContent=r.btc>0?compactUSD(r.avgCost):'—';
       el('k_value').textContent=compactUSD(value);
-      el('k_pnl').textContent=compactPercent(pnlPct);
-      if(ls){ const lsPct=invested>0?(ls.value/invested-1)*100:0; el('k_vsls').textContent=compactPercent(pnlPct-lsPct); }
+      const kpnl=el('k_pnl');
+      if(pnlPct!=null){ kpnl.textContent=compactPercent(pnlPct); kpnl.removeAttribute('title'); }
+      else{ kpnl.textContent='—'; kpnl.title='Return undefined when net invested ≤ 0'; }
+      if(ls){ const lsPct=pnlPct!=null?(ls.value/invested-1)*100:null; el('k_vsls').textContent=lsPct!=null?compactPercent(pnlPct-lsPct):'—'; }
       else{ el('k_vsls').textContent='—'; }
 
-      const tbody=el('log'); tbody.innerHTML='';
-      r.logRows.forEach((row,i)=>{
-        const investedCum=row.totalInvested, val=row.value, pnlAbs=val-investedCum, pnlPctRow=investedCum>0?(val/investedCum-1)*100:0;
-        const tr=document.createElement('tr'); tr.innerHTML=
-          `<td>${i+1}</td><td>${row.date}</td><td>${compactUSD(row.price)}</td>
-           <td>${compactUSD(investedCum)}</td><td>${compactUSD(val)}</td>
-           <td class="${pnlAbs>=0?'gain':'loss'}">${pnlAbs>=0?'+':''}${compactUSD(pnlAbs)}</td>
-           <td class="${pnlPctRow>=0?'gain':'loss'}">${pnlPctRow>=0?'+':''}${fmt(pnlPctRow,2)}%</td>`;
-        tbody.appendChild(tr);
-      });
+      const vaRow=document.getElementById(prefix+'_vaRow');
+      if(mode==='va'){
+        vaRow.style.display='grid';
+        el('k_targetStep').textContent=compactUSD(this.getTargetStep());
+        el('k_skipped').textContent=fmt(r.skipped||0,0);
+        el('k_shortfall').textContent=compactUSD(r.shortfallFinal||0);
+        if(this.getAllowSells()){ document.getElementById(prefix+'_k_grossWrap').style.display='block'; el('k_gross').textContent=`${compactUSD(r.grossBuy)} / ${compactUSD(r.grossSell)}`; }
+        else{ document.getElementById(prefix+'_k_grossWrap').style.display='none'; }
+      } else { vaRow.style.display='none'; }
+
+      const head=el('logHead'); const tbody=el('log'); tbody.innerHTML='';
+      if(mode==='va'){
+        head.innerHTML='<tr><th>#</th><th>Date</th><th>Price</th><th>Target</th><th>Action</th><th>Δ invest (USD)</th><th>Cum. Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th></tr>';
+        r.logRows.forEach((row,i)=>{
+          const pnlAbs=row.pnl_abs; const pnlPctRow=row.pnl_pct;
+          const tr=document.createElement('tr');
+          tr.innerHTML=`<td>${i+1}</td><td>${row.date}</td><td>${compactUSD(row.price)}</td><td>${compactUSD(row.target)}</td><td>${row.action}</td>`+
+                       `<td>${row.deltaUSD>=0?'+':''}${compactUSD(row.deltaUSD)}</td><td>${compactUSD(row.invested_cum)}</td><td>${compactUSD(row.value)}</td>`+
+                       `<td class="${pnlAbs>=0?'gain':'loss'}">${pnlAbs>=0?'+':''}${compactUSD(pnlAbs)}</td>`+
+                       `<td class="${pnlPctRow!=null?(pnlPctRow>=0?'gain':'loss'):''}">${pnlPctRow!=null?(pnlPctRow>=0?'+':'')+fmt(pnlPctRow,2)+'%':'—'}</td>`;
+          tbody.appendChild(tr);
+        });
+      } else {
+        head.innerHTML='<tr><th>#</th><th>Date</th><th>Price</th><th>Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th></tr>';
+        r.logRows.forEach((row,i)=>{
+          const investedCum=row.totalInvested, val=row.value, pnlAbs=val-investedCum, pnlPctRow=investedCum>0?(val/investedCum-1)*100:null;
+          const tr=document.createElement('tr');
+          tr.innerHTML=`<td>${i+1}</td><td>${row.date}</td><td>${compactUSD(row.price)}</td>`+
+                        `<td>${compactUSD(investedCum)}</td><td>${compactUSD(val)}</td>`+
+                        `<td class="${pnlAbs>=0?'gain':'loss'}">${pnlAbs>=0?'+':''}${compactUSD(pnlAbs)}</td>`+
+                        `<td class="${pnlPctRow!=null?(pnlPctRow>=0?'gain':'loss'):''}">${pnlPctRow!=null?(pnlPctRow>=0?'+':'')+fmt(pnlPctRow,2)+'%':'—'}</td>`;
+          tbody.appendChild(tr);
+        });
+      }
     },
 
     run(){
@@ -630,14 +792,23 @@ function createWorkspace(prefix){
       const base=sliceRange(sISO,eISO);
       if(base.length<5){ document.getElementById(prefix+'_status').textContent='Selected range is too short.'; return; }
 
-      const r=runDCA(base,this.frequency,this.amount,sISO,eISO);
+      const mode=this.getType();
+      let r;
+      if(mode==='va'){
+        const params={targetStep:this.getTargetStep(), initialTarget:this.getInitialTarget(), maxContribution:this.getMaxContrib(), carryShort:this.getCarryShort(), allowSells:this.getAllowSells()};
+        r=runVA(base,this.frequency,params,sISO,eISO);
+      } else {
+        r=runDCA(base,this.frequency,this.amount,sISO,eISO);
+      }
       const ls=r.firstBuyDate?calcLumpSum(r.invested,r.firstBuyDate,r.lastPrice):null;
       const ind=this.computeIndicators(r.portfolioSeries);
       this.renderCharts(r.portfolioSeries,r.investedSeries,ind);
-      this.updateKPI(r,ls);
+      this.updateKPI(r,ls,mode);
 
+      const buys=mode==='va'?r.logRows.filter(x=>x.action==='Buy').length:r.scheduleCount;
+      const sells=mode==='va'?r.logRows.filter(x=>x.action==='Sell').length:0;
       document.getElementById(prefix+'_status').textContent=
-        `Range: ${base[0].date} → ${base[base.length-1].date} • ${base.length} days • Buys: ${r.scheduleCount}`;
+        `Range: ${base[0].date} → ${base[base.length-1].date} • ${base.length} days • Buys: ${buys}${sells>0?`, Sells: ${sells}`:''}`;
     },
 
     refreshIndicatorsOnly(){
@@ -650,13 +821,15 @@ function createWorkspace(prefix){
 
     reset(){
       if(!RAW.length) return; const min=RAW[0].date, max=RAW[RAW.length-1].date;
-      el('frequency').value='weekly'; el('amount').value=100; this.ensurePickers(); this.fpStart.setDate(min,true); this.fpEnd.setDate(max,true);
+      el('type').value='dca'; this.toggleStrategy();
+      el('frequency').value='weekly'; el('amount').value=100; el('targetStep').value=100; el('initialTarget').value=100; el('maxContrib').value=''; el('carryShort').checked=true; el('allowSells').checked=false;
+      this.ensurePickers(); this.fpStart.setDate(min,true); this.fpEnd.setDate(max,true);
       el('maOn').checked=false; el('emaOn').checked=false; el('rsiOn').checked=true; el('rsiAlertOn').checked=true;
       el('maPeriod').value=50; el('emaPeriod').value=200; el('rsiPeriod').value=14; el('rsiNear').value=2;
       document.getElementById(prefix+'_status').textContent='Ready.';
       this.chartMain&&this.chartMain.destroy(); this.chartMain=null; this.chartRSI&&this.chartRSI.destroy(); this.chartRSI=null;
       el('k_trades').textContent='-'; el('k_invested').textContent='-'; el('k_btc').textContent='-'; el('k_avg').textContent='-';
-      el('k_value').textContent='-'; el('k_pnl').textContent='-'; el('k_vsls').textContent='-'; el('log').innerHTML='';
+      el('k_value').textContent='-'; el('k_pnl').textContent='-'; el('k_vsls').textContent='-'; document.getElementById(prefix+'_vaRow').style.display='none'; el('log').innerHTML='';
     },
 
     bind(){
@@ -664,25 +837,37 @@ function createWorkspace(prefix){
       this.ensurePickers();
       document.getElementById(prefix+'_runBtn').addEventListener('click', ()=>self.run());
       document.getElementById(prefix+'_resetBtn').addEventListener('click', ()=>self.reset());
+      el('type').addEventListener('change', ()=>self.toggleStrategy());
       ['maOn','emaOn','rsiOn','rsiAlertOn','maPeriod','emaPeriod','rsiPeriod','rsiNear'].forEach(id=>{
         el(id).addEventListener('change', ()=>self.refreshIndicatorsOnly());
       });
+      this.toggleStrategy();
     }
   };
   ws.bind(); return ws;
 }
 
 /* Copy & View controls */
-function copyBasic(from,to){
-  const ids=['frequency','amount','startDate','endDate'];
-  for(const k of ids){
-    const s=document.getElementById(from+'_'+k), d=document.getElementById(to+'_'+k);
-    if(!s||!d) continue; if(s.type==='checkbox') d.checked=s.checked; else d.value=s.value;
+function copyConfig(from,to){
+  const type=document.getElementById(from+'_type').value;
+  document.getElementById(to+'_type').value=type;
+  const wsTo=to==='a'?WSA:WSB; wsTo.toggleStrategy();
+  ['frequency','startDate','endDate'].forEach(k=>{
+    const s=document.getElementById(from+'_'+k), d=document.getElementById(to+'_'+k); if(s&&d) d.value=s.value;
+  });
+  if(type==='dca'){
+    document.getElementById(to+'_amount').value=document.getElementById(from+'_amount').value;
+  } else {
+    ['targetStep','initialTarget','maxContrib'].forEach(k=>{
+      const s=document.getElementById(from+'_'+k), d=document.getElementById(to+'_'+k); if(s&&d) d.value=s.value;
+    });
+    document.getElementById(to+'_carryShort').checked=document.getElementById(from+'_carryShort').checked;
+    document.getElementById(to+'_allowSells').checked=document.getElementById(from+'_allowSells').checked;
   }
 }
 const WSA=createWorkspace('a'); const WSB=createWorkspace('b');
-document.getElementById('copyAtoB').addEventListener('click', ()=>copyBasic('a','b'));
-document.getElementById('copyBtoA').addEventListener('click', ()=>copyBasic('b','a'));
+document.getElementById('copyAtoB').addEventListener('click', ()=>copyConfig('a','b'));
+document.getElementById('copyBtoA').addEventListener('click', ()=>copyConfig('b','a'));
 
 const grid=document.getElementById('gridWrap');
 function setView(mode){ grid.classList.remove('two','focusA','focusB'); grid.classList.add(mode); }


### PR DESCRIPTION
## Summary
- add strategy selector with new Value Averaging (VA) configuration per panel
- implement runVA engine with logging, KPI extras and chart compatibility
- integrate VA metrics and copy controls alongside existing DCA

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a58ccb3868832386ac96db2e2c2557