### PR TITLE
feat: add light/dark theme and UI alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.3.3</title>
+<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.4</title>
 
 <!-- Fonts & UI libs -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -28,16 +28,38 @@
     --ring: 76 145 255; /* rgb */
     --radius: 14px;
     --shadow: 0 10px 30px rgba(0,0,0,.35);
+    --grid-strong: rgba(148,163,184,.15);
+    --grid-weak:   rgba(148,163,184,.08);
+    --tick: #cbd5e1;
+    --row-odd:#0e1626;
+    --row-even:#0f1a2e;
+    --chip-bg: rgba(15,23,42,.7);
+  }
+  html[data-theme="light"]{
+    color-scheme: light;
+    --bg:#f4f6fb;
+    --panel:#ffffff;
+    --panel-2:#f9fafb;
+    --stroke:#d1d5db;
+    --stroke-2:#e2e8f0;
+    --txt:#111827;
+    --muted:#4b5563;
+    --grid-strong: rgba(0,0,0,.1);
+    --grid-weak: rgba(0,0,0,.05);
+    --tick:#374151;
+    --row-odd:#f9fafb;
+    --row-even:#f3f4f6;
+    --chip-bg: rgba(229,231,235,.7);
   }
   html,body{ background:var(--bg); color:var(--txt); font-family:Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji"; font-size:14px; }
   .panel{ background:linear-gradient(180deg, rgba(17,24,39,.6), rgba(10,15,26,.7));
           border:1px solid var(--stroke); border-radius:var(--radius); box-shadow:var(--shadow); }
-  .chip{ font-size:.72rem; padding:.28rem .6rem; border-radius:999px; background:rgba(15,23,42,.7); border:1px solid var(--stroke-2); color:var(--muted) }
+  .chip{ font-size:.72rem; padding:.28rem .6rem; border-radius:999px; background:var(--chip-bg); border:1px solid var(--stroke-2); color:var(--muted) }
 
   /* ---------- Fields ---------- */
   .field{
     display:flex; align-items:center; gap:.55rem;
-    background: radial-gradient(120% 120% at 50% -10%, rgba(255,255,255,.06) 0%, rgba(255,255,255,0) 70%) , #0c1426;
+    background: radial-gradient(120% 120% at 50% -10%, rgba(255,255,255,.06) 0%, rgba(255,255,255,0) 70%) , var(--panel-2);
     border:1px solid var(--stroke-2); border-radius:16px;
     padding: .6rem .8rem; transition: .18s border, .18s box-shadow, .18s transform;
   }
@@ -77,10 +99,16 @@
   th,td{ padding:.55rem .6rem; border-bottom:1px solid var(--stroke); font-size:.8rem }
   td{ white-space:nowrap }
   table thead th{ white-space:normal; line-height:1.2; color:var(--muted); font-weight:700; text-transform:uppercase; font-size:.68rem; letter-spacing:.04em; background:transparent }
-  tbody tr:nth-child(odd){ background:#0e1626 }
-  tbody tr:nth-child(even){ background:#0f1a2e }
+  tbody tr:nth-child(odd){ background:var(--row-odd) }
+  tbody tr:nth-child(even){ background:var(--row-even) }
   tbody tr:hover td{ filter:brightness(1.05) }
   .gain{ color:#22c55e; font-weight:600 } .loss{ color:#ef4444; font-weight:600 }
+
+  /* ---------- Theme switch ---------- */
+  #themeSwitch{ width:46px; height:24px; border-radius:999px; border:1px solid var(--stroke); background:var(--panel-2); position:relative; cursor:pointer; display:flex; align-items:center; justify-content:space-between; padding:0 6px; }
+  #themeSwitch span{ font-size:12px; pointer-events:none; }
+  #themeSwitch .knob{ position:absolute; top:2px; left:2px; width:20px; height:20px; border-radius:50%; background:var(--txt); transition:transform .25s; }
+  html[data-theme="light"] #themeSwitch .knob{ transform:translateX(22px); }
 
   /* ---------- Indicators row ---------- */
   .ind-row{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:12px; }
@@ -114,9 +142,15 @@
       <div class="flex items-center gap-3 flex-wrap">
         <h1 class="text-2xl md:text-3xl font-extrabold leading-tight">Bitcoin DCA Backtester — Dual Strategy (Offline)</h1>
         <span class="chip">Source: Local JSON (daily close, USD)</span>
-        <span class="chip">Dual v1.3.3</span>
+        <span class="chip">Dual v1.4</span>
       </div>
       <p class="text-sm" style="color:var(--muted)">Load a USD price JSON once. Compare two DCA strategies side-by-side. No internet calls.</p>
+    </div>
+    <div id="themeToggle">
+      <div id="themeSwitch">
+        <span>☀️</span><span>🌙</span>
+        <div class="knob"></div>
+      </div>
     </div>
   </header>
 
@@ -144,8 +178,15 @@
   <div id="gridWrap" class="two">
     <!-- Strategy A -->
     <div id="A">
-      <h2 class="text-lg md:text-xl font-bold mb-3">Strategy A</h2>
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-lg md:text-xl font-bold">Strategy A</h2>
+        <div class="flex gap-2">
+          <button id="a_runBtn" class="btn" disabled>Backtest</button>
+          <button id="a_resetBtn" class="btn ghost" type="button">Reset</button>
+        </div>
+      </div>
 
+      <div class="chip mb-2">Controls</div>
       <section id="a_ctrl" class="controls panel p-4 md:p-5 mb-5">
         <div class="grid grid-cols-1 md:grid-cols-7 gap-3 items-end">
           <div>
@@ -187,15 +228,12 @@
             <div class="label">End date</div>
             <div class="field"><input id="a_endDate" type="text" placeholder="YYYY-MM-DD" /></div>
           </div>
-          <div class="flex gap-2 col-span-2">
-            <button id="a_runBtn" class="btn w-full" disabled>Backtest</button>
-            <button id="a_resetBtn" class="btn ghost" type="button">Reset</button>
-          </div>
         </div>
-        <p class="text-xs mt-3" id="a_rangeHint" style="color:var(--muted)">Load a JSON file to enable the date range.</p>
+        <p class="text-xs mt-3" id="a_rangeHint" style="color:var(--muted)">Select a date range.</p>
       </section>
 
-      <section id="a_kpi" class="kpi grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
+      <div class="chip mb-2">Results</div>
+      <section id="a_kpi" class="results kpi grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
         <div class="panel p-3.5"><div class="label">Duration</div><div id="a_k_duration" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Buys</div><div id="a_k_trades" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Total invested</div><div id="a_k_invested" class="value mt-1">-</div></div>
@@ -206,14 +244,13 @@
         <div class="panel p-3.5"><div class="label">vs. Lump-sum</div><div id="a_k_vsls" class="value mt-1">-</div></div>
       </section>
 
+      <div class="chip mb-2">Charts</div>
       <section id="a_chartWrap" class="chart-wrap panel p-4 md:p-5">
         <div class="flex items-center justify-between mb-2">
           <h3 class="text-base md:text-lg font-semibold">Portfolio over time (A)</h3>
           <div id="a_status" class="text-xs md:text-sm" style="color:var(--muted)">Awaiting data…</div>
         </div>
-        <div style="height:420px"><canvas id="a_chartMain"></canvas></div>
-
-        <div class="ind-row mt-3">
+        <div class="ind-row mb-3">
           <div class="panel ind-card">
             <div class="switch">
               <input type="checkbox" id="a_maOn"><label for="a_maOn" style="color:var(--muted)">SMA</label>
@@ -245,6 +282,8 @@
           </div>
         </div>
 
+        <div style="height:420px"><canvas id="a_chartMain"></canvas></div>
+
         <div class="text-[11px] mt-3" style="color:var(--muted)">*Prices & returns based on historical data. Not investment advice.</div>
       </section>
 
@@ -255,8 +294,8 @@
         </div>
         <div style="height:170px"><canvas id="a_chartRSI"></canvas></div>
       </section>
-
-      <details id="a_logWrap" class="table-wrap panel p-4 md:p-5 mt-5" open>
+      <div class="chip mt-5 mb-2">Details</div>
+      <details id="a_logWrap" class="details table-wrap panel p-4 md:p-5" open>
         <summary class="cursor-pointer font-semibold text-base">Transaction details (A)</summary>
         <div class="mt-3">
           <table class="tbl-compact">
@@ -269,8 +308,15 @@
 
     <!-- Strategy B -->
     <div id="B">
-      <h2 class="text-lg md:text-xl font-bold mb-3">Strategy B</h2>
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-lg md:text-xl font-bold">Strategy B</h2>
+        <div class="flex gap-2">
+          <button id="b_runBtn" class="btn" disabled>Backtest</button>
+          <button id="b_resetBtn" class="btn ghost" type="button">Reset</button>
+        </div>
+      </div>
 
+      <div class="chip mb-2">Controls</div>
       <section id="b_ctrl" class="controls panel p-4 md:p-5 mb-5">
         <div class="grid grid-cols-1 md:grid-cols-7 gap-3 items-end">
           <div>
@@ -312,15 +358,12 @@
             <div class="label">End date</div>
             <div class="field"><input id="b_endDate" type="text" placeholder="YYYY-MM-DD" /></div>
           </div>
-          <div class="flex gap-2 col-span-2">
-            <button id="b_runBtn" class="btn w-full" disabled>Backtest</button>
-            <button id="b_resetBtn" class="btn ghost" type="button">Reset</button>
-          </div>
         </div>
-        <p class="text-xs mt-3" id="b_rangeHint" style="color:var(--muted)">Load a JSON file to enable the date range.</p>
+        <p class="text-xs mt-3" id="b_rangeHint" style="color:var(--muted)">Select a date range.</p>
       </section>
 
-      <section id="b_kpi" class="kpi grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
+      <div class="chip mb-2">Results</div>
+      <section id="b_kpi" class="results kpi grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
         <div class="panel p-3.5"><div class="label">Duration</div><div id="b_k_duration" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Buys</div><div id="b_k_trades" class="value mt-1">-</div></div>
         <div class="panel p-3.5"><div class="label">Total invested</div><div id="b_k_invested" class="value mt-1">-</div></div>
@@ -331,14 +374,13 @@
         <div class="panel p-3.5"><div class="label">vs. Lump-sum</div><div id="b_k_vsls" class="value mt-1">-</div></div>
       </section>
 
+      <div class="chip mb-2">Charts</div>
       <section id="b_chartWrap" class="chart-wrap panel p-4 md:p-5">
         <div class="flex items-center justify-between mb-2">
           <h3 class="text-base md:text-lg font-semibold">Portfolio over time (B)</h3>
           <div id="b_status" class="text-xs md:text-sm" style="color:var(--muted)">Awaiting data…</div>
         </div>
-        <div style="height:420px"><canvas id="b_chartMain"></canvas></div>
-
-        <div class="ind-row mt-3">
+        <div class="ind-row mb-3">
           <div class="panel ind-card">
             <div class="switch">
               <input type="checkbox" id="b_maOn"><label for="b_maOn" style="color:var(--muted)">SMA</label>
@@ -370,6 +412,8 @@
           </div>
         </div>
 
+        <div style="height:420px"><canvas id="b_chartMain"></canvas></div>
+
         <div class="text-[11px] mt-3" style="color:var(--muted)">*Prices & returns based on historical data. Not investment advice.</div>
       </section>
 
@@ -380,8 +424,8 @@
         </div>
         <div style="height:170px"><canvas id="b_chartRSI"></canvas></div>
       </section>
-
-      <details id="b_logWrap" class="table-wrap panel p-4 md:p-5 mt-5" open>
+      <div class="chip mt-5 mb-2">Details</div>
+      <details id="b_logWrap" class="details table-wrap panel p-4 md:p-5" open>
         <summary class="cursor-pointer font-semibold text-base">Transaction details (B)</summary>
         <div class="mt-3">
           <table class="tbl-compact">
@@ -395,6 +439,29 @@
 </div>
 
 <script>
+/* ===== Theme ===== */
+const theme=localStorage.theme||'dark';
+document.documentElement.dataset.theme=theme;
+function themeColors(){
+  const cs=getComputedStyle(document.documentElement);
+  return {
+    gridStrong:cs.getPropertyValue('--grid-strong').trim(),
+    gridWeak:cs.getPropertyValue('--grid-weak').trim(),
+    tick:cs.getPropertyValue('--tick').trim()
+  };
+}
+function updateChartTheme(ws){
+  if(!ws) return; const c=themeColors();
+  [ws.chartMain,ws.chartRSI].forEach(ch=>{
+    if(!ch) return; const o=ch.options;
+    if(o.scales.x){ o.scales.x.grid.color=c.gridWeak; if(o.scales.x.ticks) o.scales.x.ticks.color=c.tick; }
+    if(o.scales.y){ o.scales.y.grid.color=c.gridStrong; if(o.scales.y.ticks) o.scales.y.ticks.color=c.tick; }
+    if(o.scales.y1){ o.scales.y1.grid.drawOnChartArea=false; if(o.scales.y1.ticks) o.scales.y1.ticks.color=c.tick; }
+    if(o.plugins.legend && o.plugins.legend.labels){ o.plugins.legend.labels.color=c.tick; }
+    ch.update('none');
+  });
+}
+
 /* ===== RSI alert plugin (unchanged) ===== */
 const rsiAlertPlugin={id:'rsiAlert',afterDatasetsDraw(chart,args,opts){
   if(!opts||!opts.enabled||!opts.rsi||!opts.rsi.length) return;
@@ -544,13 +611,13 @@ function mh(aSel,bSel){
   a.style.minHeight=b.style.minHeight=h+'px';
 }
 function matchHeights(){
-  mh('#A .controls','#B .controls');
-  mh('#A .kpi','#B .kpi');
+  mh('#A .controls', '#B .controls');
+  mh('#A .results', '#B .results');
   mh('#A .chart-wrap','#B .chart-wrap');
-  mh('#A .rsi-wrap','#B .rsi-wrap');
-  mh('#A .table-wrap','#B .table-wrap');
+  mh('#A .rsi-wrap', '#B .rsi-wrap');
+  mh('#A .details', '#B .details');
 }
-const debouncedMH=(()=>{ let t; return ()=>{ clearTimeout(t); t=setTimeout(matchHeights,150);} })();
+const debouncedMH = (()=>{ let t; return ()=>{ clearTimeout(t); t=setTimeout(matchHeights,150);} })();
 window.addEventListener('resize',debouncedMH);
 
 /* Indicators */
@@ -591,7 +658,18 @@ function createWorkspace(prefix){
       this.ensurePickers();
       this.fpStart.set('minDate',minISO); this.fpStart.set('maxDate',maxISO); this.fpStart.setDate(minISO, true);
       this.fpEnd.set('minDate',minISO);   this.fpEnd.set('maxDate',maxISO);   this.fpEnd.setDate(maxISO, true);
-      el('rangeHint').textContent=`Data range: ${minISO} → ${maxISO}. Choose any dates within.`;
+      this.updateRangeHint();
+    },
+
+    updateRangeHint(){
+      const hint=el('rangeHint');
+      if(!RAW.length){ hint.textContent='Select a date range.'; return; }
+      const sISO=this.sISO, eISO=this.eISO;
+      if(!sISO || !eISO || sISO>eISO){ hint.textContent='Select a date range.'; return; }
+      const base=sliceRange(sISO,eISO);
+      if(!base.length){ hint.textContent='Select a date range.'; return; }
+      const buys=buildSchedule(this.frequency,sISO,eISO).length;
+      hint.textContent=`Selected range: ${base[0].date} → ${base[base.length-1].date} • ${base.length} days • Buys: ${buys}`;
     },
 
     computeIndicators(series){
@@ -617,6 +695,7 @@ function createWorkspace(prefix){
       const price    = series.map(p=>p.price);
       const value    = series.map(p=>p.value);
       const invested = investedSeries.map(p=>p.invested);
+      const tc = themeColors();
 
       const datasets = [
         { label:'BTC price (USD)', data:price, yAxisID:'y',  borderColor:'#22c55e', pointRadius:0, tension:.25, borderWidth:2,   cubicInterpolationMode:'monotone', spanGaps:true },
@@ -632,13 +711,14 @@ function createWorkspace(prefix){
         data:{ labels, datasets },
         options:{
           responsive:true, maintainAspectRatio:false, interaction:{ mode:'index', intersect:false },
+          animation:{ onComplete:debouncedMH },
           scales:{
-            y :{ position:'left',  grid:{ color:'rgba(148,163,184,.15)' }, ticks:{ callback:v=>compactUSD(v) } },
-            y1:{ position:'right', grid:{ drawOnChartArea:false },      ticks:{ callback:v=>compactUSD(v) } },
-            x :{ grid:{ color:'rgba(148,163,184,.08)' }, ticks:{ maxTicksLimit:10 } }
+            y :{ position:'left',  grid:{ color:tc.gridStrong }, ticks:{ color:tc.tick, callback:v=>compactUSD(v) } },
+            y1:{ position:'right', grid:{ color:tc.gridStrong, drawOnChartArea:false },      ticks:{ color:tc.tick, callback:v=>compactUSD(v) } },
+            x :{ grid:{ color:tc.gridWeak }, ticks:{ color:tc.tick, maxTicksLimit:10 } }
           },
           plugins:{
-            legend:{ labels:{ color:'#cbd5e1', font:{ size:11 } } },
+            legend:{ labels:{ color:tc.tick, font:{ size:11 } } },
             tooltip:{
               backgroundColor:'#0f172a', borderColor:'#2b3a58', borderWidth:1, padding:10,
               callbacks:{
@@ -676,11 +756,12 @@ function createWorkspace(prefix){
         },
         options:{
           responsive:true, maintainAspectRatio:false, interaction:{ mode:'index', intersect:false },
+          animation:{ onComplete:debouncedMH },
           scales:{
-            y:{ min:0, max:100, ticks:{ color:'#9aa4b2' }, grid:{ color:'rgba(148,163,184,.12)' } },
-            x:{ grid:{ color:'rgba(148,163,184,.08)' }, ticks:{ maxTicksLimit:10 } }
+            y:{ min:0, max:100, ticks:{ color:tc.tick }, grid:{ color:tc.gridStrong } },
+            x:{ grid:{ color:tc.gridWeak }, ticks:{ color:tc.tick, maxTicksLimit:10 } }
           },
-          plugins:{ legend:{ labels:{ color:'#cbd5e1', font:{ size:11 } } } }
+          plugins:{ legend:{ labels:{ color:tc.tick, font:{ size:11 } } } }
         }
       });
     }, // end renderCharts
@@ -740,7 +821,8 @@ function createWorkspace(prefix){
       const buys=mode==='va'?r.logRows.filter(x=>x.invested>0).length:r.scheduleCount;
       document.getElementById(prefix+'_status').textContent=
         `Range: ${base[0].date} → ${base[base.length-1].date} • ${base.length} days • Buys: ${buys}`;
-      matchHeights();
+      this.updateRangeHint();
+      debouncedMH();
     },
 
     refreshIndicatorsOnly(){
@@ -762,7 +844,8 @@ function createWorkspace(prefix){
       this.chartMain&&this.chartMain.destroy(); this.chartMain=null; this.chartRSI&&this.chartRSI.destroy(); this.chartRSI=null;
       el('k_duration').textContent='-'; el('k_trades').textContent='-'; el('k_invested').textContent='-'; el('k_btc').textContent='-'; el('k_avg').textContent='-';
       el('k_value').textContent='-'; el('k_pnl').textContent='-'; el('k_vsls').textContent='-'; el('log').innerHTML='';
-      matchHeights();
+      this.updateRangeHint();
+      debouncedMH();
     },
 
     bind(){
@@ -770,6 +853,9 @@ function createWorkspace(prefix){
       this.ensurePickers();
       document.querySelectorAll('#'+prefix.toUpperCase()+' input, #'+prefix.toUpperCase()+' select').forEach(el=>{
         ['input','change'].forEach(ev=>el.addEventListener(ev,debouncedMH));
+      });
+      ['startDate','endDate','frequency'].forEach(id=>{
+        el(id).addEventListener('change', ()=>{ self.updateRangeHint(); debouncedMH(); });
       });
       document.getElementById(prefix+'_runBtn').addEventListener('click', ()=>self.run());
       document.getElementById(prefix+'_resetBtn').addEventListener('click', ()=>self.reset());
@@ -798,18 +884,28 @@ function copyConfig(from,to){
       const s=document.getElementById(from+'_'+k), d=document.getElementById(to+'_'+k); if(s&&d) d.value=s.value;
     });
   }
+  wsTo.updateRangeHint();
   debouncedMH();
 }
 const WSA=createWorkspace('a'); const WSB=createWorkspace('b');
 document.getElementById('copyAtoB').addEventListener('click', ()=>copyConfig('a','b'));
 document.getElementById('copyBtoA').addEventListener('click', ()=>copyConfig('b','a'));
 
+document.getElementById('themeSwitch').addEventListener('click', ()=>{
+  const next=document.documentElement.dataset.theme==='light'?'dark':'light';
+  document.documentElement.dataset.theme=next;
+  localStorage.theme=next;
+  updateChartTheme(WSA); updateChartTheme(WSB);
+  debouncedMH();
+});
+updateChartTheme(WSA); updateChartTheme(WSB);
+
 const grid=document.getElementById('gridWrap');
-function setView(mode){ grid.classList.remove('two','focusA','focusB'); grid.classList.add(mode); matchHeights(); }
+function setView(mode){ grid.classList.remove('two','focusA','focusB'); grid.classList.add(mode); debouncedMH(); }
 document.getElementById('focusA').addEventListener('click', ()=>setView('focusA'));
 document.getElementById('focusB').addEventListener('click', ()=>setView('focusB'));
 document.getElementById('splitView').addEventListener('click', ()=>setView('two'));
-matchHeights();
+debouncedMH();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add light/dark theme toggle with persisted preference and dynamic chart styling
- reorganize strategy sections with header buttons, chips, and selected range hints
- align A/B panel heights and reorder indicator and RSI layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db097dc08323beb36474a0d0785b