### PR TITLE
v1.4.8 — remove WDCA ratios, USD presets, engine stabilization

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.4.7</title>
+<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.4.8</title>
 
 <!-- Fonts & UI libs -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -172,7 +172,7 @@
       <div class="flex items-center gap-3 flex-wrap">
         <h1 class="text-2xl md:text-3xl font-extrabold leading-tight">Bitcoin DCA Backtester — Dual Strategy (Offline)</h1>
         <span class="chip">Source: Local JSON (daily close, USD)</span>
-        <span class="chip">Dual v1.4.7</span>
+        <span class="chip">Dual v1.4.8</span>
         <span id="wdcaBadge" class="chip hidden">WDCA beta</span>
       </div>
       <p class="text-sm" style="color:var(--muted)">Load a USD price JSON once. Compare two DCA strategies side-by-side. No internet calls.</p>
@@ -552,14 +552,6 @@
             <div class="field"><input id="c_alpha" class="num-s" type="number" step="0.01" value="0.35" /></div>
           </div>
           <div>
-            <div class="label">Min ratio</div>
-            <div class="field"><input id="c_minRatio" class="num-s" type="number" step="0.01" value="0.5" /></div>
-          </div>
-          <div>
-            <div class="label">Max ratio</div>
-            <div class="field"><input id="c_maxRatio" class="num-s" type="number" step="0.01" value="3" /></div>
-          </div>
-          <div>
             <div class="label">Preset</div>
             <div class="field">
               <select id="c_preset">
@@ -735,55 +727,28 @@ function setInputValue(el,x){ const s=(Math.round(Number(x)*1e6)/1e6).toString()
 let WDCA_SYNCING=false;
 function roundToStep(x,step){ step=Number(step)||1; return Math.round(x/step)*step; }
 function showAmtHint(prefix,clamped){ const h=getI(prefix,'amtHint'); if(h) h.textContent=clamped?'Adjusted to limits':''; }
-function syncRatiosFromAmounts(prefix){
+function syncRatiosFromAmounts(){/* removed in v1.4.8 */}
+function syncAmountsFromRatios(){/* removed in v1.4.8 */}
+function sanitizeAmounts(prefix){
   if(WDCA_SYNCING) return; WDCA_SYNCING=true;
   try{
-    const base=num(getI(prefix,'base').value)||0;
-    let min=num(getI(prefix,'min').value)||0;
-    let max=num(getI(prefix,'max').value)||0;
+    const minEl=getI(prefix,'min');
+    const maxEl=getI(prefix,'max');
+    let min=num(minEl.value)||0;
+    let max=num(maxEl.value)||0;
     let clamped=false;
     if(min<0){min=0;clamped=true;}
+    if(max<0){max=0;clamped=true;}
     if(max<min){max=min;clamped=true;}
-    setInputValue(getI(prefix,'min'),min);
-    setInputValue(getI(prefix,'max'),max);
-    if(base>0){
-      setInputValue(getI(prefix,'minRatio'),(min/base).toFixed(2));
-      setInputValue(getI(prefix,'maxRatio'),(max/base).toFixed(2));
-    } else {
-      setInputValue(getI(prefix,'minRatio'),0);
-      setInputValue(getI(prefix,'maxRatio'),0);
-    }
-    showAmtHint(prefix,clamped);
-  } finally { WDCA_SYNCING=false; }
-}
-function syncAmountsFromRatios(prefix){
-  if(WDCA_SYNCING) return; WDCA_SYNCING=true;
-  try{
-    const base=num(getI(prefix,'base').value)||0;
-    const step=num(getI(prefix,'step').value)||1;
-    let rmin=num(getI(prefix,'minRatio').value)||0;
-    let rmax=num(getI(prefix,'maxRatio').value)||0;
-    let clamped=false;
-    if(rmin<0){rmin=0;clamped=true;}
-    if(rmin>1){rmin=1;clamped=true;}
-    if(rmax<1){rmax=1;clamped=true;}
-    if(rmax<rmin){rmax=Math.max(rmin,1);clamped=true;}
-    const min=roundToStep(base>0?base*rmin:0,step);
-    const max=roundToStep(base>0?base*rmax:0,step);
-    setInputValue(getI(prefix,'min'),min);
-    setInputValue(getI(prefix,'max'),max);
-    setInputValue(getI(prefix,'minRatio'),rmin.toFixed(2));
-    setInputValue(getI(prefix,'maxRatio'),rmax.toFixed(2));
+    setInputValue(minEl,min);
+    setInputValue(maxEl,max);
     showAmtHint(prefix,clamped);
   } finally { WDCA_SYNCING=false; }
 }
 const WDCA_PRESETS={
-  Conservative:{ base:100,minRatio:0.70,maxRatio:2.20, overdraft:0, step:5,
-    ema:100,rsi:14,sensTrend:0.10,sensCost:0.12,wTrend:0.5,wCost:0.3,wRsi:0.2,alpha:0.25 },
-  Standard:{ base:100,minRatio:0.50,maxRatio:3.00, overdraft:0, step:5,
-    ema:50,rsi:14,sensTrend:0.08,sensCost:0.10,wTrend:0.5,wCost:0.3,wRsi:0.2,alpha:0.35 },
-  Aggressive:{ base:100,minRatio:0.40,maxRatio:3.50, overdraft:200, step:5,
-    ema:50,rsi:14,sensTrend:0.06,sensCost:0.08,wTrend:0.45,wCost:0.35,wRsi:0.2,alpha:0.45 }
+  Conservative: { base:100, min:70,  max:220, overdraft:0,   step:5,  ema:100, rsi:14, sensTrend:0.10, sensCost:0.12, wTrend:0.5, wCost:0.3, wRsi:0.2, alpha:0.45 },
+  Standard:     { base:100, min:50,  max:300, overdraft:0,   step:5,  ema:50,  rsi:14, sensTrend:0.08, sensCost:0.10, wTrend:0.5, wCost:0.3, wRsi:0.2, alpha:0.35 },
+  Aggressive:   { base:100, min:40,  max:350, overdraft:200, step:5,  ema:50,  rsi:14, sensTrend:0.06, sensCost:0.08, wTrend:0.45, wCost:0.35, wRsi:0.2, alpha:0.45 },
 };
 function alignRsi(main,rsi){ if(!main||!rsi) return; const ca=main.chartArea; rsi.options.layout=rsi.options.layout||{}; rsi.options.layout.padding={left:ca.left,right:main.width-ca.right}; rsi.update('none'); }
 function compactUSD(x){ const abs=Math.abs(x), u=[{v:1e12,s:'T'},{v:1e9,s:'B'},{v:1e6,s:'M'},{v:1e3,s:'K'}];
@@ -914,6 +879,7 @@ function runWDCA(series,freq,p,sISO,eISO){
   let bankMin=0, hitsMin=0, hitsMax=0, multSum=0, prevScore=0;
   const log=[], port=[], invS=[];
   const EPS=p.step>0?p.step*0.5:1e-9;
+  const safe=v=>Number.isFinite(v)?v:null;
   for(let i=0;i<series.length;i++){
     const row=series[i]; const price=row.close; const date=row.date;
     if(set.has(date)){
@@ -926,21 +892,30 @@ function runWDCA(series,freq,p,sISO,eISO){
       let s3=0; if(rsi!=null){ if(rsi<=30) s3=1; else if(rsi>=70) s3=-1; else s3=(50-rsi)/20; }
       const scoreRaw=(p.wTrend*s1+p.wCost*s2+p.wRsi*s3)/wSum;
       const score=clamp((1-p.alpha)*prevScore+p.alpha*scoreRaw,-1,1); prevScore=score;
-      let f=score>=0?1+score*(p.maxRatio-1):1+score*(1-p.minRatio);
+      const rmin=p.base>0?(p.min/p.base):0;
+      const rmax=p.base>0?(p.max/p.base):1;
+      const f=score>=0?1+score*(rmax-1):1+score*(1-rmin);
       let desired=clamp(f*p.base,p.min,p.max);
-      if(p.step>0) desired=Math.round(desired/p.step)*p.step;
-      let invest=Math.min(desired,bank+p.overdraft);
-      invest=Math.max(invest,p.min);
-      bank-=invest; if(bank<bankMin) bankMin=bank;
-      if(invest>0){ const qty=invest/price; btc+=qty; invested+=invest; if(!firstBuyDate) firstBuyDate=date; }
-      multSum+=invest/p.base;
-      if(Math.abs(invest-p.min)<=EPS) hitsMin++;
-      if(Math.abs(invest-p.max)<=EPS) hitsMax++;
-      const value=btc*price;
-      log.push({date, price, invested:invest, totalInvested:invested, value, score, s1, s2, s3, f, bank});
+      const afford=bank+p.overdraft;
+      let invest=Math.min(desired,afford);
+      invest=Math.max(invest,Math.min(p.min,afford));
+      invest=roundToStep(invest,p.step);
+      invest=Math.min(invest,afford);
+      if(invest<=0){
+        if(bank<bankMin) bankMin=bank;
+        log.push({date, price:safe(price), invested:0, totalInvested:invested, value:safe(btc*price), score:safe(score), s1:safe(s1), s2:safe(s2), s3:safe(s3), f:safe(f), bank:safe(bank)});
+      }else{
+        bank-=invest; if(bank<bankMin) bankMin=bank;
+        const qty=invest/price; btc+=qty; invested+=invest; if(!firstBuyDate) firstBuyDate=date;
+        multSum+=invest/p.base;
+        if(Math.abs(invest-p.min)<=EPS) hitsMin++;
+        if(Math.abs(invest-p.max)<=EPS) hitsMax++;
+        const value=btc*price;
+        log.push({date, price:safe(price), invested:safe(invest), totalInvested:safe(invested), value:safe(value), score:safe(score), s1:safe(s1), s2:safe(s2), s3:safe(s3), f:safe(f), bank:safe(bank)});
+      }
     }
-    invS.push({date, invested});
-    port.push({date, price, value:btc*price, invested});
+    invS.push({date, invested:safe(invested)});
+    port.push({date, price:safe(price), value:safe(btc*price), invested:safe(invested)});
   }
   const lastEntry=series[series.length-1]; const last=lastEntry.close;
   return { scheduleCount:schedule.length, invested, btc, avgCost:btc?invested/btc:0, lastPrice:last, lastPriceDate:lastEntry.date, value:btc*last,
@@ -966,8 +941,6 @@ function createWorkspaceC(prefix){
     get wCost(){ return Math.max(0, num(el('wCost').value)||0); },
     get wRsi(){ return Math.max(0, num(el('wRsi').value)||0); },
     get alpha(){ return clamp(num(el('alpha').value)||0.35,0,1); },
-    get minRatio(){ return clamp(num(el('minRatio').value)||0.5,0,1); },
-    get maxRatio(){ return Math.max(1, num(el('maxRatio').value)||3); },
     get preset(){ return el('preset').value; },
     get sISO(){ return el('start').value; },
     get eISO(){ return el('end').value; },
@@ -1011,10 +984,11 @@ function createWorkspaceC(prefix){
       if(this.chartMain) this.chartMain.destroy();
       if(this.chartRSI)  this.chartRSI.destroy();
 
+      const safe=v=>Number.isFinite(v)?v:null;
       const labels=series.map(p=>p.date);
-      const price=series.map(p=>p.price);
-      const value=series.map(p=>p.value);
-      const invested=investedSeries.map(p=>p.invested);
+      const price=series.map(p=>safe(p.price));
+      const value=series.map(p=>safe(p.value));
+      const invested=investedSeries.map(p=>safe(p.invested));
       const tc=themeColors();
       const isDark=document.documentElement.classList.contains('dark') || document.documentElement.dataset.theme!=='light';
       const datasets=[
@@ -1094,10 +1068,10 @@ function createWorkspaceC(prefix){
       });
 
       const rsiEmbed=document.getElementById(prefix+'_rsiEmbed');
-      if(indicators.rsi){
+      if(indicators.rsi && indicators.rsi.some(v=>v!=null)){
         rsiEmbed.style.display='';
         const ctxRsi=document.getElementById(prefix+'_chartRSI').getContext('2d');
-        const rsiData=indicators.rsi;
+        const rsiData=indicators.rsi.map(v=>safe(v));
         document.getElementById(prefix+'_rsiLegend').textContent=this.rsiP;
         this.chartRSI=new Chart(ctxRsi,{
           type:'line',
@@ -1129,8 +1103,7 @@ function createWorkspaceC(prefix){
     updateKPI(r,ls){
       const invested=r.invested, bank=r.bankFinal, portfolio=r.value;
       const finalValue=portfolio+bank;
-      const denom=invested+bank;
-      const pnlPct=denom>0 && isFinite(finalValue)?(finalValue/denom-1)*100:null;
+      const pnlPct=invested>0 && isFinite(finalValue)?(finalValue/invested-1)*100:null;
       const buyCount=r.scheduleCount;
       const kdur=el('k_duration');
       if(r.firstBuyDate) kdur.textContent=humanDuration(r.firstBuyDate,r.lastPriceDate); else kdur.textContent='—';
@@ -1141,7 +1114,7 @@ function createWorkspaceC(prefix){
       const kval=el('k_value'); kval.textContent=isFinite(finalValue)?compactUSD(finalValue):'—'; kval.title='Portfolio + bank (cash)';
       const kpnl=el('k_pnl');
       if(pnlPct!=null && isFinite(pnlPct)){ kpnl.textContent=compactPercent(pnlPct); kpnl.removeAttribute('title'); }
-      else{ kpnl.textContent='—'; kpnl.title='Return undefined when net invested + bank ≤ 0'; }
+      else{ kpnl.textContent='—'; kpnl.title='Return undefined when invested ≤ 0'; }
       if(ls){ const lsPct=pnlPct!=null && invested>0 && isFinite(ls.value)?(ls.value/invested-1)*100:null; el('k_vsls').textContent=lsPct!=null&&pnlPct!=null&&isFinite(pnlPct-lsPct)?compactPercent(pnlPct-lsPct):'—'; }
       else{ el('k_vsls').textContent='—'; }
       el('k_bankFinal').textContent=isFinite(r.bankFinal)?compactUSD(r.bankFinal):'—';
@@ -1153,8 +1126,8 @@ function createWorkspaceC(prefix){
                 ['k_invested_ab',res=>res?compactUSD(res.invested):null],
                 ['k_btc_ab',res=>res?fmt(res.btc,3):null],
                 ['k_avg_ab',res=>res?(res.btc>0?compactUSD(res.avgCost):'—'):null],
-                ['k_value_ab',res=>res?compactUSD(res.value):null],
-                ['k_pnl_ab',res=>{ if(res&&res.invested>0){ const pct=(res.value/res.invested-1)*100; return compactPercent(pct);} return null; }]];
+                ['k_value_ab',res=>res?compactUSD(res.value+(res.bankFinal||0)):null],
+                ['k_pnl_ab',res=>{ if(res&&res.invested>0){ const pct=((res.value+(res.bankFinal||0))/res.invested-1)*100; return compactPercent(pct);} return null; }]];
       ab.forEach(([id,fn])=>{
         const a=fn(WSA.lastResult), b=fn(WSB.lastResult); const elab=el(id);
         if(elab){ const parts=[]; if(a!=null) parts.push('A: '+a); if(b!=null) parts.push('B: '+b); elab.textContent=parts.join(' • '); elab.style.display=parts.length?'block':'none'; }
@@ -1162,12 +1135,14 @@ function createWorkspaceC(prefix){
 
       const head=el('logHead'); const tbody=el('log'); tbody.innerHTML='';
       head.innerHTML='<tr><th>#</th><th>Date</th><th>Price</th><th>Invest (USD)</th><th>Sum Invested</th><th>Port. Value</th><th>Δ$</th><th>Δ%</th><th>Score</th><th>s1</th><th>s2</th><th>s3</th><th>f</th><th>Bank</th></tr>';
-      if(!r.logRows.length){
+      const hasBuy=r.logRows.some(row=>row.invested>0);
+      if(!hasBuy){
         const tr=document.createElement('tr');
         tr.innerHTML='<td colspan="14" style="text-align:center;color:var(--muted)">No transactions</td>';
         tbody.appendChild(tr);
       } else {
         r.logRows.forEach((row,i)=>{
+          if(row.invested<=0) return;
           const investedPer=row.invested, investedCum=row.totalInvested, val=row.value;
           const pnlAbs=val-investedCum, pnlPctRow=investedCum>0?(val/investedCum-1)*100:null;
           const tr=document.createElement('tr');
@@ -1190,7 +1165,7 @@ function createWorkspaceC(prefix){
 
       const params={ base:this.base, min:this.min, max:this.max, overdraft:this.overdraft, step:this.step, ema:this.ema, rsi:this.rsi,
                      sensTrend:this.sensTrend, sensCost:this.sensCost, wTrend:this.wTrend, wCost:this.wCost, wRsi:this.wRsi,
-                     alpha:this.alpha, minRatio:this.minRatio, maxRatio:this.maxRatio };
+                     alpha:this.alpha };
       const r=runWDCA(base,this.frequency,params,sISO,eISO);
       this.lastResult=r;
       const ls=r.firstBuyDate?calcLumpSum(r.invested,r.firstBuyDate,r.lastPrice):null;
@@ -1214,8 +1189,8 @@ function createWorkspaceC(prefix){
     reset(){
       if(!RAW.length) return; const min=RAW[0].date, max=RAW[RAW.length-1].date;
       el('freq').value='weekly'; el('base').value=100; el('min').value=50; el('max').value=300; el('overdraft').value=0; el('step').value=5;
-      el('ema').value=50; el('rsi').value=14; el('sensTrend').value=0.08; el('sensCost').value=0.10; el('wTrend').value=0.5; el('wCost').value=0.3; el('wRsi').value=0.2; el('alpha').value=0.35; el('minRatio').value=0.5; el('maxRatio').value=3; el('preset').value='standard';
-      syncRatiosFromAmounts(prefix);
+      el('ema').value=50; el('rsi').value=14; el('sensTrend').value=0.08; el('sensCost').value=0.10; el('wTrend').value=0.5; el('wCost').value=0.3; el('wRsi').value=0.2; el('alpha').value=0.35; el('preset').value='standard';
+      sanitizeAmounts(prefix);
       this.ensurePickers(); this.fpStart.setDate(min,true); this.fpEnd.setDate(max,true);
       el('maOn').checked=false; el('emaOn').checked=false; el('rsiOn').checked=true; el('rsiAlertOn').checked=true;
       el('maPeriod').value=50; el('emaPeriod').value=200; el('rsiPeriod').value=14; el('rsiNear').value=2;
@@ -1237,17 +1212,22 @@ function createWorkspaceC(prefix){
         document.getElementById(prefix+'_runBtn').addEventListener('click',()=>self.run());
         document.getElementById(prefix+'_resetBtn').addEventListener('click',()=>self.reset());
         ['maOn','emaOn','rsiOn','rsiAlertOn','maPeriod','emaPeriod','rsiPeriod','rsiNear'].forEach(id=>{ el(id).addEventListener('change',()=>self.refreshIndicatorsOnly()); });
-        ['min','max','step'].forEach(id=>{
-          el(id).addEventListener('input',()=>syncRatiosFromAmounts(prefix));
+        ['base','min','max','step'].forEach(id=>{
+          const elm=el(id);
+          ['input','change'].forEach(ev=>{
+            elm.addEventListener(ev,e=>{
+              if(e.type==='change'){
+                const v=num(elm.value);
+                setInputValue(elm,(id==='base'||id==='step')?Math.max(0,v):v);
+                sanitizeAmounts(prefix);
+              }
+            });
+          });
         });
-        ['minRatio','maxRatio'].forEach(id=>{
-          el(id).addEventListener('input',()=>syncAmountsFromRatios(prefix));
-        });
-        el('base').addEventListener('input',()=>syncAmountsFromRatios(prefix));
         el('preset').addEventListener('change',()=>{
           const sel=el('preset').value; const key=sel.charAt(0).toUpperCase()+sel.slice(1);
           const cfg=WDCA_PRESETS[key];
-          if(cfg){ Object.entries(cfg).forEach(([k,v])=>{ const inp=getI(prefix,k); if(inp) setInputValue(inp,v); }); syncAmountsFromRatios(prefix); }
+          if(cfg){ Object.entries(cfg).forEach(([k,v])=>{ const inp=getI(prefix,k); if(inp) setInputValue(inp,v); }); sanitizeAmounts(prefix); }
         });
       }
   };


### PR DESCRIPTION
## Summary
- drop WDCA Min/Max Ratio fields and wire up USD-only controls
- derive rmin/rmax from USD, clamp buys to budget, round at end
- restore Results/Details/RSI rendering and switch presets to USD

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b50ae06083239128606442a85bf2