### PR TITLE
v1.4.10 — fix chart recursion & WDCA clamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.4.8</title>
+<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.4.10</title>
 
 <!-- Fonts & UI libs -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -172,7 +172,7 @@
       <div class="flex items-center gap-3 flex-wrap">
         <h1 class="text-2xl md:text-3xl font-extrabold leading-tight">Bitcoin DCA Backtester — Dual Strategy (Offline)</h1>
         <span class="chip">Source: Local JSON (daily close, USD)</span>
-        <span class="chip">Dual v1.4.8</span>
+        <span class="chip">Dual v1.4.10</span>
         <span id="wdcaBadge" class="chip hidden">WDCA beta</span>
       </div>
       <p class="text-sm" style="color:var(--muted)">Load a USD price JSON once. Compare two DCA strategies side-by-side. No internet calls.</p>
@@ -318,7 +318,7 @@
           </div>
 
         <div style="height:420px"><canvas id="a_chartMain"></canvas></div>
-        <div class="rsi-embed mt-4" id="a_rsiEmbed">
+        <div class="rsi-embed mt-4" id="a_rsiWrap">
           <div class="flex items-center justify-between mb-2">
             <div class="text-sm" style="color:var(--muted)">RSI (A)</div>
             <div class="text-xs" style="color:var(--muted)"><span id="a_rsiLegend">14</span> by default – overbought 70, oversold 30</div>
@@ -450,7 +450,7 @@
           </div>
 
         <div style="height:420px"><canvas id="b_chartMain"></canvas></div>
-        <div class="rsi-embed mt-4" id="b_rsiEmbed">
+        <div class="rsi-embed mt-4" id="b_rsiWrap">
           <div class="flex items-center justify-between mb-2">
             <div class="text-sm" style="color:var(--muted)">RSI (B)</div>
             <div class="text-xs" style="color:var(--muted)"><span id="b_rsiLegend">14</span> by default – overbought 70, oversold 30</div>
@@ -635,7 +635,7 @@
           </div>
         </div>
         <div style="height:420px"><canvas id="c_chartMain"></canvas></div>
-        <div class="rsi-embed mt-4" id="c_rsiEmbed">
+        <div class="rsi-embed mt-4" id="c_rsiWrap">
           <div class="flex items-center justify-between mb-2">
             <div class="text-sm" style="color:var(--muted)">RSI (C)</div>
             <div class="text-xs" style="color:var(--muted)"><span id="c_rsiLegend">14</span> by default – overbought 70, oversold 30</div>
@@ -707,13 +707,7 @@ const rsiAlertPlugin={id:'rsiAlert',beforeDatasetsDraw(chart,args,opts){
   }
   ctx.restore();
 }};
-const rsiAligner={id:'rsiAligner',afterLayout(chart,_args,opts){
-  if(!opts||!opts.main||!opts.main.chartArea) return;
-  const ca=opts.main.chartArea;
-  chart.options.layout=chart.options.layout||{};
-  chart.options.layout.padding={left:ca.left,right:opts.main.width-ca.right};
-}};
-Chart.register(crosshairPlugin,rsiAlertPlugin,rsiAligner);
+Chart.register(crosshairPlugin,rsiAlertPlugin);
 
 /* ===== Shared state & helpers ===== */
 let RAW=[], PRICE_MAP=null;
@@ -724,34 +718,46 @@ const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
 const num=v=>Number(String(v).replace(/\s/g,'').replace(',','.'));
 const getI=(p,id)=>document.getElementById(p+'_'+id);
 function setInputValue(el,x){ const s=(Math.round(Number(x)*1e6)/1e6).toString(); el.value=s; }
-let WDCA_SYNCING=false;
 function roundToStep(x,step){ step=Number(step)||1; return Math.floor(x/step)*step; }
-function showAmtHint(prefix,clamped){ const h=getI(prefix,'amtHint'); if(h) h.textContent=clamped?'Adjusted to limits':''; }
-const safe=v=>Number.isFinite(v)?v:null;
-function syncRatiosFromAmounts(){/* removed v1.4.8+ */}
-function syncAmountsFromRatios(){/* removed v1.4.8+ */}
-function sanitizeAmounts(prefix){
-  if(WDCA_SYNCING) return; WDCA_SYNCING=true;
-  try{
-    const minEl=getI(prefix,'min');
-    const maxEl=getI(prefix,'max');
-    let min=num(minEl.value)||0;
-    let max=num(maxEl.value)||0;
-    let clamped=false;
-    if(min<0){min=0;clamped=true;}
-    if(max<0){max=0;clamped=true;}
-    if(max<min){max=min;clamped=true;}
-    setInputValue(minEl,min);
-    setInputValue(maxEl,max);
-    showAmtHint(prefix,clamped);
-  } finally { WDCA_SYNCING=false; }
+function safe(v){ return Number.isFinite(v)?v:null; }
+function destroyChartByCanvasId(id){
+  var el=document.getElementById(id);
+  if(!el) return;
+  var old=Chart.getChart(el);
+  if(old) old.destroy();
 }
 const WDCA_PRESETS={
   Conservative: { base:100, min:70,  max:220, overdraft:0,   step:5,  ema:100, rsi:14, sensTrend:0.10, sensCost:0.12, wTrend:0.5, wCost:0.3, wRsi:0.2, alpha:0.45 },
   Standard:     { base:100, min:50,  max:300, overdraft:0,   step:5,  ema:50,  rsi:14, sensTrend:0.08, sensCost:0.10, wTrend:0.5, wCost:0.3, wRsi:0.2, alpha:0.35 },
   Aggressive:   { base:100, min:40,  max:350, overdraft:200, step:5,  ema:50,  rsi:14, sensTrend:0.06, sensCost:0.08, wTrend:0.45, wCost:0.35, wRsi:0.2, alpha:0.45 },
 };
-function alignRsi(main,rsi){ if(!main||!rsi) return; const ca=main.chartArea; rsi.options.layout=rsi.options.layout||{}; rsi.options.layout.padding={left:ca.left,right:main.width-ca.right}; rsi.update('none'); }
+function alignRsi(main,rsi){
+  if(!main||!rsi) return;
+  const ca=main.chartArea;
+  rsi.options.layout=rsi.options.layout||{};
+  rsi.options.layout.padding={left:ca.left,right:main.width-ca.right};
+  rsi.update('none');
+}
+function debounce(fn,ms){ let t; return function(){ clearTimeout(t); t=setTimeout(fn,ms); }; }
+function setStatus(prefix,text){ const el=document.getElementById(prefix+'_status'); if(el) el.textContent=text; }
+function clampWdca(){
+  var base=Number(String(document.getElementById('c_base').value).replace(',','.'))||0;
+  var min =Number(String(document.getElementById('c_min').value).replace(',','.'))||0;
+  var max =Number(String(document.getElementById('c_max').value).replace(',','.'))||0;
+  var step=Math.max(1,Number(String(document.getElementById('c_step').value).replace(',','.'))||1);
+  min=Math.max(0,min);
+  base=Math.max(min,base);
+  max=Math.max(base,max);
+  document.getElementById('c_min').value=min;
+  document.getElementById('c_base').value=base;
+  document.getElementById('c_max').value=max;
+  document.getElementById('c_step').value=step;
+}
+['c_min','c_base','c_max','c_step'].forEach(function(id){
+  var el=document.getElementById(id);
+  if(el){ el.addEventListener('input',clampWdca); el.addEventListener('change',clampWdca); }
+});
+clampWdca();
 function compactUSD(x){ const abs=Math.abs(x), u=[{v:1e12,s:'T'},{v:1e9,s:'B'},{v:1e6,s:'M'},{v:1e3,s:'K'}];
   for(const k of u){ if(abs>=k.v) return '$'+(x/k.v).toFixed(abs>=1e9?2:1).replace(/\.0+$/,'')+k.s; }
   return '$'+Number(x).toLocaleString('en-US',{maximumFractionDigits:0}); }
@@ -798,7 +804,7 @@ function onDataLoaded(arr){
   document.getElementById('loadStatus').textContent = `Loaded ${RAW.length} rows • ${minISO} → ${maxISO}`;
   WSA.setRangeInputs(minISO,maxISO); WSB.setRangeInputs(minISO,maxISO); WSC.setRangeInputs(minISO,maxISO);
   document.getElementById('a_runBtn').disabled=false; document.getElementById('b_runBtn').disabled=false; document.getElementById('c_runBtn').disabled=false;
-  document.getElementById('a_status').textContent='Ready.'; document.getElementById('b_status').textContent='Ready.'; document.getElementById('c_status').textContent='Ready.';
+  setStatus('a','Ready.'); setStatus('b','Ready.'); setStatus('c','Ready.');
 }
 
 /* File load */
@@ -982,8 +988,10 @@ function createWorkspaceC(prefix){
     },
 
     renderCharts(series,investedSeries,indicators){
-      if(this.chartMain) this.chartMain.destroy();
-      if(this.chartRSI)  this.chartRSI.destroy();
+      destroyChartByCanvasId(prefix+'_chartMain');
+      destroyChartByCanvasId(prefix+'_chartRSI');
+      this.chartMain=null;
+      this.chartRSI=null;
 
       const labels=series.map(p=>p.date);
       let price=series.map(p=>p.price); price=price.map(safe);
@@ -1068,9 +1076,9 @@ function createWorkspaceC(prefix){
         }
       });
 
-      const rsiEmbed=document.getElementById(prefix+'_rsiEmbed');
-      if(rsiData && rsiData.some(v=>v!=null)){
-        rsiEmbed.style.display='';
+      const rsiWrap=document.getElementById(prefix+'_rsiWrap');
+      if(rsiData && rsiData.length && rsiData.some(v=>v!=null)){
+        rsiWrap.style.display='';
         const ctxRsi=document.getElementById(prefix+'_chartRSI').getContext('2d');
         document.getElementById(prefix+'_rsiLegend').textContent=this.rsiP;
         this.chartRSI=new Chart(ctxRsi,{
@@ -1090,12 +1098,13 @@ function createWorkspaceC(prefix){
               y:{min:0,max:100,ticks:{color:tc.tick},grid:{color:tc.gridStrong}},
               x:{grid:{color:tc.gridWeak,drawTicks:false},ticks:{color:tc.tick,maxTicksLimit:10,display:false}}
             },
-            plugins:{tooltip:{enabled:false},legend:{labels:{color:tc.tick,font:{size:11}}},rsiAlert:{enabled:this.rsiAlertOn,spans:rsiSpans},rsiAligner:{main:this.chartMain}}
+            plugins:{tooltip:{enabled:false},legend:{labels:{color:tc.tick,font:{size:11}}},rsiAlert:{enabled:this.rsiAlertOn,spans:rsiSpans}}
           }
         });
-        requestAnimationFrame(()=>alignRsi(this.chartMain,this.chartRSI));
+        var ws=this;
+        requestAnimationFrame(function(){ alignRsi(ws.chartMain,ws.chartRSI); });
       } else {
-        if(rsiEmbed) rsiEmbed.style.display='none';
+        if(rsiWrap) rsiWrap.style.display='none';
         this.chartRSI=null;
       }
     },
@@ -1164,31 +1173,35 @@ function createWorkspaceC(prefix){
     },
 
     run(){
-      if(!RAW.length){ document.getElementById(prefix+'_status').textContent='No data loaded.'; return; }
+      if(!RAW.length){ setStatus(prefix,'No data loaded.'); return; }
       const sISO=this.sISO, eISO=this.eISO;
-      if(!sISO || !eISO || sISO>eISO){ document.getElementById(prefix+'_status').textContent='Invalid date range.'; return; }
-      const base=sliceRange(sISO,eISO); if(base.length<5){ document.getElementById(prefix+'_status').textContent='Selected range is too short.'; return; }
-
+      if(!sISO || !eISO || sISO>eISO){ setStatus(prefix,'Invalid date range.'); return; }
+      const base=sliceRange(sISO,eISO); if(base.length<5){ setStatus(prefix,'Selected range is too short.'); return; }
+      clampWdca();
+      let r;
       try{
         const params={ base:this.base, min:this.min, max:this.max, overdraft:this.overdraft, step:this.step, ema:this.ema, rsi:this.rsi,
                        sensTrend:this.sensTrend, sensCost:this.sensCost, wTrend:this.wTrend, wCost:this.wCost, wRsi:this.wRsi,
                        alpha:this.alpha };
-        const r=runWDCA(base,this.frequency,params,sISO,eISO);
-        this.lastResult=r;
-        const ls=r.firstBuyDate?calcLumpSum(r.invested,r.firstBuyDate,r.lastPrice):null;
-        const ind=this.computeIndicators(r.portfolioSeries);
-        this.renderCharts(r.portfolioSeries,r.investedSeries,ind);
-        this.updateKPI(r,ls);
-        const buys=r.scheduleCount;
-        document.getElementById(prefix+'_status').textContent=`Range: ${base[0].date} → ${base[base.length-1].date} • ${base.length} days • Buys: ${buys}`;
-        this.updateRangeHint();
-        debouncedMH();
+        r=runWDCA(base,this.frequency,params,sISO,eISO);
       } catch(err){
-        const s=document.getElementById(prefix+'_status')||document.getElementById('c_status');
-        if(s) s.textContent='Error: '+err.message;
         console.error('[Backtest '+prefix.toUpperCase()+']',err);
+        setStatus(prefix,'Error: '+err.message);
         return;
       }
+      this.lastResult=r;
+      const ls=r.firstBuyDate?calcLumpSum(r.invested,r.firstBuyDate,r.lastPrice):null;
+      this.updateKPI(r,ls);
+      try{
+        const ind=this.computeIndicators(r.portfolioSeries);
+        this.renderCharts(r.portfolioSeries,r.investedSeries,ind);
+        setStatus(prefix,'Ready.');
+      } catch(e){
+        console.error('[Backtest '+prefix.toUpperCase()+']',e);
+        setStatus(prefix,'Error: '+e.message);
+      }
+      this.updateRangeHint();
+      debouncedMH();
     },
 
     refreshIndicatorsOnly(){
@@ -1203,11 +1216,11 @@ function createWorkspaceC(prefix){
       if(!RAW.length) return; const min=RAW[0].date, max=RAW[RAW.length-1].date;
       el('freq').value='weekly'; el('base').value=100; el('min').value=50; el('max').value=300; el('overdraft').value=0; el('step').value=5;
       el('ema').value=50; el('rsi').value=14; el('sensTrend').value=0.08; el('sensCost').value=0.10; el('wTrend').value=0.5; el('wCost').value=0.3; el('wRsi').value=0.2; el('alpha').value=0.35; el('preset').value='standard';
-      sanitizeAmounts(prefix);
+      clampWdca();
       this.ensurePickers(); this.fpStart.setDate(min,true); this.fpEnd.setDate(max,true);
       el('maOn').checked=false; el('emaOn').checked=false; el('rsiOn').checked=true; el('rsiAlertOn').checked=true;
       el('maPeriod').value=50; el('emaPeriod').value=200; el('rsiPeriod').value=14; el('rsiNear').value=2;
-      document.getElementById(prefix+'_status').textContent='Ready.';
+      setStatus(prefix,'Ready.');
       this.chartMain&&this.chartMain.destroy(); this.chartMain=null; this.chartRSI&&this.chartRSI.destroy(); this.chartRSI=null;
       ['k_duration','k_trades','k_invested','k_btc','k_avg','k_value','k_pnl','k_vsls','k_bankFinal','k_bankMin','k_avgMult','k_hits'].forEach(id=>{ el(id).textContent='-'; });
       ['k_trades_ab','k_invested_ab','k_btc_ab','k_avg_ab','k_value_ab','k_pnl_ab'].forEach(id=>{ el(id).textContent=''; });
@@ -1225,22 +1238,10 @@ function createWorkspaceC(prefix){
         document.getElementById(prefix+'_runBtn').addEventListener('click',()=>self.run());
         document.getElementById(prefix+'_resetBtn').addEventListener('click',()=>self.reset());
         ['maOn','emaOn','rsiOn','rsiAlertOn','maPeriod','emaPeriod','rsiPeriod','rsiNear'].forEach(id=>{ el(id).addEventListener('change',()=>self.refreshIndicatorsOnly()); });
-        ['base','min','max','step'].forEach(id=>{
-          const elm=el(id);
-          ['input','change'].forEach(ev=>{
-            elm.addEventListener(ev,e=>{
-              if(e.type==='change'){
-                const v=num(elm.value);
-                setInputValue(elm,(id==='base'||id==='step')?Math.max(0,v):v);
-                sanitizeAmounts(prefix);
-              }
-            });
-          });
-        });
         el('preset').addEventListener('change',()=>{
           const sel=el('preset').value; const key=sel.charAt(0).toUpperCase()+sel.slice(1);
           const cfg=WDCA_PRESETS[key];
-          if(cfg){ Object.entries(cfg).forEach(([k,v])=>{ const inp=getI(prefix,k); if(inp) setInputValue(inp,v); }); sanitizeAmounts(prefix); }
+          if(cfg){ Object.entries(cfg).forEach(([k,v])=>{ const inp=getI(prefix,k); if(inp) setInputValue(inp,v); }); clampWdca(); }
         });
       }
   };
@@ -1267,7 +1268,7 @@ function matchHeights(){
   mh('#A .chart-wrap','#B .chart-wrap');
   mh('#A .details', '#B .details');
 }
-const debouncedMH = (()=>{ let t; return ()=>{ clearTimeout(t); t=setTimeout(matchHeights,150);} })();
+const debouncedMH = debounce(matchHeights,150);
 window.addEventListener('resize',debouncedMH);
 
 /* Indicators */
@@ -1339,8 +1340,10 @@ function createWorkspace(prefix){
     },
 
     renderCharts(series, investedSeries, indicators){
-      if(this.chartMain) this.chartMain.destroy();
-      if(this.chartRSI)  this.chartRSI.destroy();
+      destroyChartByCanvasId(prefix+'_chartMain');
+      destroyChartByCanvasId(prefix+'_chartRSI');
+      this.chartMain=null;
+      this.chartRSI=null;
 
       const labels   = series.map(p=>p.date);
       let price    = series.map(p=>p.price);     price    = price.map(safe);
@@ -1426,9 +1429,9 @@ function createWorkspace(prefix){
         }
       });
 
-      const rsiEmbed=document.getElementById(prefix+'_rsiEmbed');
-      if(rsiData && rsiData.some(v=>v!=null)){
-        rsiEmbed.style.display='';
+      const rsiWrap=document.getElementById(prefix+'_rsiWrap');
+      if(rsiData && rsiData.length && rsiData.some(v=>v!=null)){
+        rsiWrap.style.display='';
         const ctxRsi=document.getElementById(prefix+'_chartRSI').getContext('2d');
         document.getElementById(prefix+'_rsiLegend').textContent=this.rsiP;
         this.chartRSI=new Chart(ctxRsi,{
@@ -1448,12 +1451,13 @@ function createWorkspace(prefix){
               y:{ min:0, max:100, ticks:{ color:tc.tick }, grid:{ color:tc.gridStrong } },
               x:{ grid:{ color:tc.gridWeak, drawTicks:false }, ticks:{ color:tc.tick, maxTicksLimit:10, display:false } }
             },
-            plugins:{ tooltip:{enabled:false}, legend:{ labels:{ color:tc.tick, font:{ size:11 } } }, rsiAlert:{ enabled:this.rsiAlertOn, spans:rsiSpans }, rsiAligner:{ main:this.chartMain } }
+            plugins:{ tooltip:{enabled:false}, legend:{ labels:{ color:tc.tick, font:{ size:11 } } }, rsiAlert:{ enabled:this.rsiAlertOn, spans:rsiSpans } }
           }
         });
-        requestAnimationFrame(()=>alignRsi(this.chartMain,this.chartRSI));
+        var ws=this;
+        requestAnimationFrame(function(){ alignRsi(ws.chartMain,ws.chartRSI); });
       } else {
-        if(rsiEmbed) rsiEmbed.style.display='none';
+        if(rsiWrap) rsiWrap.style.display='none';
         this.chartRSI=null;
       }
     }, // end renderCharts
@@ -1502,38 +1506,39 @@ function createWorkspace(prefix){
     },
 
     run(){
-      if(!RAW.length){ document.getElementById(prefix+'_status').textContent='No data loaded.'; return; }
+      if(!RAW.length){ setStatus(prefix,'No data loaded.'); return; }
       const sISO=this.sISO, eISO=this.eISO;
-      if(!sISO || !eISO || sISO>eISO){ document.getElementById(prefix+'_status').textContent='Invalid date range.'; return; }
+      if(!sISO || !eISO || sISO>eISO){ setStatus(prefix,'Invalid date range.'); return; }
       const base=sliceRange(sISO,eISO);
-      if(base.length<5){ document.getElementById(prefix+'_status').textContent='Selected range is too short.'; return; }
+      if(base.length<5){ setStatus(prefix,'Selected range is too short.'); return; }
 
+      const mode=this.getType();
+      let r;
       try{
-        const mode=this.getType();
-        let r;
         if(mode==='va'){
           const params={targetStep:this.getTargetStep(), maxContribution:this.getMaxContrib()};
           r=runVA(base,this.frequency,params,sISO,eISO);
         } else {
           r=runDCA(base,this.frequency,this.amount,sISO,eISO);
         }
-        this.lastResult=r;
-        const ls=r.firstBuyDate?calcLumpSum(r.invested,r.firstBuyDate,r.lastPrice):null;
-        const ind=this.computeIndicators(r.portfolioSeries);
-        this.renderCharts(r.portfolioSeries,r.investedSeries,ind);
-        this.updateKPI(r,ls,mode);
-
-        const buys=mode==='va'?r.logRows.filter(x=>x.invested>0).length:r.scheduleCount;
-        document.getElementById(prefix+'_status').textContent=
-          `Range: ${base[0].date} → ${base[base.length-1].date} • ${base.length} days • Buys: ${buys}`;
-        this.updateRangeHint();
-        debouncedMH();
       } catch(err){
-        const s=document.getElementById(prefix+'_status')||document.getElementById('c_status');
-        if(s) s.textContent='Error: '+err.message;
         console.error('[Backtest '+prefix.toUpperCase()+']',err);
+        setStatus(prefix,'Error: '+err.message);
         return;
       }
+      this.lastResult=r;
+      const ls=r.firstBuyDate?calcLumpSum(r.invested,r.firstBuyDate,r.lastPrice):null;
+      this.updateKPI(r,ls,mode);
+      try{
+        const ind=this.computeIndicators(r.portfolioSeries);
+        this.renderCharts(r.portfolioSeries,r.investedSeries,ind);
+        setStatus(prefix,'Ready.');
+      } catch(e){
+        console.error('[Backtest '+prefix.toUpperCase()+']',e);
+        setStatus(prefix,'Error: '+e.message);
+      }
+      this.updateRangeHint();
+      debouncedMH();
     },
 
     refreshIndicatorsOnly(){
@@ -1551,7 +1556,7 @@ function createWorkspace(prefix){
       this.ensurePickers(); this.fpStart.setDate(min,true); this.fpEnd.setDate(max,true);
       el('maOn').checked=false; el('emaOn').checked=false; el('rsiOn').checked=true; el('rsiAlertOn').checked=true;
       el('maPeriod').value=50; el('emaPeriod').value=200; el('rsiPeriod').value=14; el('rsiNear').value=2;
-      document.getElementById(prefix+'_status').textContent='Ready.';
+      setStatus(prefix,'Ready.');
       this.chartMain&&this.chartMain.destroy(); this.chartMain=null; this.chartRSI&&this.chartRSI.destroy(); this.chartRSI=null;
       el('k_duration').textContent='-'; el('k_trades').textContent='-'; el('k_invested').textContent='-'; el('k_btc').textContent='-'; el('k_avg').textContent='-';
       el('k_value').textContent='-'; el('k_pnl').textContent='-'; el('k_vsls').textContent='-'; el('log').innerHTML='';
@@ -1602,8 +1607,10 @@ function copyConfig(from,to){
   debouncedMH();
 }
 const WSA=createWorkspace('a'); const WSB=createWorkspace('b'); const WSC=createWorkspace('c');
-function syncAllRsi(){ [WSA,WSB,WSC].forEach(ws=>{ if(ws.chartMain&&ws.chartRSI) alignRsi(ws.chartMain,ws.chartRSI); }); }
-window.addEventListener('resize',syncAllRsi);
+const realign = debounce(function(){
+  [WSA,WSB,WSC].forEach(function(ws){ alignRsi(ws && ws.chartMain, ws && ws.chartRSI); });
+},100);
+window.addEventListener('resize', realign, { passive:true });
 document.getElementById('copyAtoB').addEventListener('click', ()=>copyConfig('a','b'));
 document.getElementById('copyBtoA').addEventListener('click', ()=>copyConfig('b','a'));
 
@@ -1659,7 +1666,7 @@ document.getElementById('themeSwitch').addEventListener('click', ()=>{
   localStorage.theme=next;
   updateChartTheme(WSA); updateChartTheme(WSB); updateChartTheme(WSC);
   WSA.refreshIndicatorsOnly(); WSB.refreshIndicatorsOnly(); WSC.refreshIndicatorsOnly();
-  syncAllRsi();
+  realign();
   debouncedMH();
 });
 updateChartTheme(WSA); updateChartTheme(WSB); updateChartTheme(WSC);
@@ -1669,7 +1676,7 @@ function setView(mode){
   grid.classList.remove('two','focusA','focusB','wdca');
   grid.classList.add(mode);
   [WSA,WSB,WSC].forEach(ws=>{ if(ws.chartMain) ws.chartMain.resize(); if(ws.chartRSI) ws.chartRSI.resize(); });
-  syncAllRsi();
+  realign();
   debouncedMH();
 }
 document.getElementById('focusA').addEventListener('click', ()=>setView('focusA'));
@@ -1677,7 +1684,7 @@ document.getElementById('focusB').addEventListener('click', ()=>setView('focusB'
 document.getElementById('splitView').addEventListener('click', ()=>setView('two'));
 document.getElementById('btnWDCA').addEventListener('click', ()=>setView('wdca'));
 debouncedMH();
-syncAllRsi();
+realign();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove recursive RSI layout plugin and align RSI panels after render
- destroy and recreate charts safely with sanitized data, preserving KPIs on chart errors
- finalize WDCA USD-only controls with simple clamping

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c4334db88323bc6c9af208099224