### PR TITLE
v1.5.4 – WDCA Buy/Sell chart displays independent Buy (green) and Sell (red) bars

### DIFF
--- a/DCA Backtest — Dual v1.5.4.html
+++ b/DCA Backtest — Dual v1.5.4.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.5.3</title>
+<title>Bitcoin DCA Backtester — Dual Strategy (Offline) · Dual v1.5.4</title>
 
 <!-- Fonts & UI libs -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -179,7 +179,7 @@
       <div class="flex items-center gap-3 flex-wrap">
         <h1 class="text-2xl md:text-3xl font-extrabold leading-tight">Bitcoin DCA Backtester — Dual Strategy (Offline)</h1>
         <span class="chip">Source: Local JSON (daily close, USD)</span>
-        <span class="chip">Dual v1.5.3</span>
+        <span class="chip">Dual v1.5.4</span>
         <span id="wdcaBadge" class="chip hidden">WDCA beta</span>
       </div>
       <p class="text-sm" style="color:var(--muted)">Load a USD price JSON once. Compare two DCA strategies side-by-side. No internet calls.</p>
@@ -1278,16 +1278,24 @@ function createWorkspaceC(prefix){
       this.chartBS=null;
 
       const labels=series.map(p=>p.date);
-      const bars=Array(labels.length).fill(null);
+      const buyBars=Array(labels.length).fill(null);
+      const sellBars=Array(labels.length).fill(null);
       if(this.lastResult && Array.isArray(this.lastResult.logRows)){
-        const labelIndex=new Map(labels.map((d,i)=>[d,i]));
+        const idxByDate=new Map(labels.map((d,i)=>[d,i]));
         for(const r of this.lastResult.logRows){
-          const idx=labelIndex.get(r.date);
-          if(idx!=null){ const val=Number(r.invested)||0; bars[idx]=val!==0?val:null; }
+          const idx=idxByDate.get(r.date); if(idx==null) continue;
+          const v=Number(r.invested)||0;
+          if(v>0)      buyBars[idx]=(buyBars[idx] ?? 0)+v;
+          else if(v<0) sellBars[idx]=(sellBars[idx]??0)+v;
         }
       }
       const tradeWrap=document.getElementById('c_tradeWrap');
-      if(bars.some(v=>v!=null)) tradeWrap.style.display=''; else tradeWrap.style.display='none';
+      if(buyBars.some(v=>v!=null) || sellBars.some(v=>v!=null)) tradeWrap.style.display=''; else tradeWrap.style.display='none';
+      const maxBuy = Math.max(0, ...buyBars.map(v=>v??0));
+      const minSell = Math.min(0, ...sellBars.map(v=>v??0));
+      const pad=0.05;
+      const suggestedMax = Number.isFinite(maxBuy) ? maxBuy*(1+pad) : undefined;
+      const suggestedMin = Number.isFinite(minSell)? minSell*(1+pad): undefined;
 
       let price=series.map(p=>p.price); price=price.map(safe);
       let value=series.map(p=>p.value); value=value.map(safe);
@@ -1405,17 +1413,20 @@ function createWorkspaceC(prefix){
         const ctxBS=document.getElementById(prefix+'_chartBS').getContext('2d');
         this.chartBS=new Chart(ctxBS,{
           type:'bar',
-          data:{labels,datasets:[{label:'Trades (USD)',data:bars,backgroundColor:ctx=>{const v=ctx.raw; if(v==null) return 'rgba(0,0,0,0)'; return v>=0?'rgba(34,197,94,.8)':'rgba(239,68,68,.8)';},borderWidth:0} ]},
+          data:{labels,datasets:[
+            {label:'Buys (USD)', data:buyBars, backgroundColor:'rgba(34,197,94,.85)', borderWidth:0, barPercentage:0.95, categoryPercentage:0.9},
+            {label:'Sells (USD)',data:sellBars,backgroundColor:'rgba(239,68,68,.85)',borderWidth:0,barPercentage:0.95,categoryPercentage:0.9}
+          ]},
           options:{
             responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},
             animation:{onComplete:debouncedMH},
             scales:{
-              y:{ticks:{color:tc.tick,callback:v=>compactUSD(v)},grid:{color:tc.gridStrong}},
+              y:{ticks:{color:tc.tick,callback:v=>compactUSD(v)},grid:{color:tc.gridStrong},suggestedMax:suggestedMax,suggestedMin:suggestedMin},
               x:{grid:{color:tc.gridWeak,drawTicks:false},ticks:{color:tc.tick,display:false}}
             },
             plugins:{
               legend:{labels:{color:tc.tick,font:{size:11}}},
-              tooltip:{callbacks:{label:ctx=>{const v=ctx.raw||0; const t=v>=0?'Buy':'Sell'; return `${t}: ${compactUSD(Math.abs(v))}`;}}},
+              tooltip:{callbacks:{label:(ctx)=>{const raw=Number(ctx.raw)||0; const abs=compactUSD(Math.abs(raw)); return `${ctx.dataset.label}: ${raw>=0?'+':'−'}${abs}`;} }},
               rsiAlert:{enabled:this.rsiAlertOn,spans:rsiSpans},
               crosshair:true
             }


### PR DESCRIPTION
## Summary
- bump version to Dual v1.5.4
- render Buy/Sell chart as two datasets (green buys, red sells) without overwriting
- keep WDCA Sell and Buy engines independent

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72ec537b08323b28ba7eac69252dc